### PR TITLE
actually use markdown-it

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -8,7 +8,7 @@ module.exports = function(html) {
 //
 // helpers
 //
-var rmk = new (require('remarkable'))('commonmark', {
+var rmk = new (require('markdown-it'))('commonmark', {
   html        : true,
   xhtmlOut    : false,
   breaks      : false,


### PR DESCRIPTION
This module is borked at the moment because it is still trying to `require('remarkable')`.
